### PR TITLE
fix: added project banner to index website

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,7 +573,7 @@
             </nav>
         
             <!-- Project Banner -->
-            <img class="screenshot" src="/api/placeholder/1200/400" alt="Project Banner">
+            <img class="screenshot" src="/assets/img/project banner card.jpg" alt="Project Banner">
         
             <!-- Stats Grid -->
             <div class="stats-container">


### PR DESCRIPTION
This website replaces the placeholder value of project banner with actual path. This was a bug